### PR TITLE
Breaking out the key policies to utilize their own resource call.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,4 +10,14 @@ crash.log
 # password, private keys, and other secrets. These should not be part of version
 # control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
+*.tfvars
 
+# OS generated files #
+######################
+.DS_Store
+.DS_Store?
+._*
+.Spotlight-V100
+.Trashes
+ehthumbs.db
+Thumbs.db

--- a/examples/kp-key/main.tf
+++ b/examples/kp-key/main.tf
@@ -19,4 +19,6 @@ module "kms_key" {
   standard_key_type      = var.standard_key_type
   force_delete           = var.force_delete
   network_access_allowed = var.network_access_allowed
+  rotation               = var.rotation
+  dual_auth_delete       = var.dual_auth_delete
 }

--- a/examples/kp-key/variables.tf
+++ b/examples/kp-key/variables.tf
@@ -14,6 +14,14 @@ variable "resource_group" {
   type        = string
   description = "Resource group of instance"
 }
+######################################
+# Key Protect Instance Variables
+######################################
+variable "is_kp_instance_exist" {
+  default     = false
+  description = "Determines if kp instance exists on not. If false, it creates and instance with given name."
+  type        = bool
+}
 variable "service_name" {
   type        = string
   description = "Name of KMS Instance"
@@ -21,17 +29,26 @@ variable "service_name" {
 variable "location" {
   type        = string
   description = "Location of KMS Instance"
+  default     = null
+}
+variable "plan" {
+  type        = string
+  description = "Plan of KMS Instance"
+  default     = null
 }
 variable "allowed_network_policy" {
   default     = null
   type        = string
-  description = "Types of the service endpoints. Possible values are 'private', 'public-and-private'."
+  description = "Types of the service endpoints. Possible values are 'public', 'private', 'public-and-private'."
 }
 variable "tags" {
   default     = null
   type        = set(string)
-  description = "Tags for the cms"
+  description = "Tags for the KMS Instance"
 }
+######################################
+# Key Protect Key Variables
+######################################
 variable "key_name" {
   description = "Name of the Key"
   type        = string
@@ -50,4 +67,43 @@ variable "force_delete" {
   description = "Determines if it has to be force deleted"
   default     = null
   type        = bool
+}
+variable "encrypted_nonce" {
+  description = "Encrypted_nonce of the Key"
+  type        = string
+  default     = null
+}
+variable "iv_value" {
+  description = "Iv_value of the Key"
+  type        = string
+  default     = null
+}
+variable "key_material" {
+  description = "key_material of the Key"
+  type        = string
+  default     = null
+}
+variable "expiration_date" {
+  description = "Expiration_date of the Key"
+  type        = string
+  default     = null
+}
+
+######################################
+# Key Protect Key Policies Variables
+######################################
+variable "endpoint_type" {
+  description = "The type of the public or private endpoint to be used for fetching policies."
+  type        = string
+  default     = null
+}
+variable "rotation" {
+  description = "The key rotation time interval in months, with a minimum of 1, and a maximum of 12."
+  type        = object({ interval_month = number })
+  default     = null
+}
+variable "dual_auth_delete" {
+  description = "Enable or disable dual auth delete on keys. Enabled requires 2 levels of approval to delete a key. Default is false."
+  type        = bool
+  default     = false
 }

--- a/modules/key-protect/README.md
+++ b/modules/key-protect/README.md
@@ -18,6 +18,7 @@ module "kms_key" {
   standard_key_type      = var.standard_key_type
   force_delete           = var.force_delete
   network_access_allowed = var.network_access_allowed
+  rotation               = var.rotation 
 }
 
 ```
@@ -42,26 +43,9 @@ module "kms_key" {
 | encrypted_nonce          | Encrypted Nonce. Only for imported root key.                   |`string`| n/a     | no      |
 | iv_value                 | IV Value. Only for imported root key.                          |`string`| n/a     | no      |
 | expiration_date          | Expination Date.                                               |`string`| n/a     | no      |
-| policies                 | Set policies for a key.                                        |`list(map)`| n/a  | no      |
-
-## policies Inputs
-
-| Name                     | Description                                                    | Type   |Default  |Required |
-|--------------------------|-------------------------------------------------------|:-------|:--------|:--------|
-| rotation                 | Specifies the key rotation time interval in months    |`map(string)`| n/a| Atleast one of rotation/dual_auth_delete|
-| dual_auth_delete         | Data associated with the dual authorization delete policy.|`map(string)`| n/a | Atleast one of rotation/dual_auth_delete|
-
-## rotation Inputs
-
-| Name                     | Description                                                    | Type   |Default  |Required |
-|--------------------------|----------------------------------------------------------------|:-------|:--------|:--------|
-| interval_month        | Specifies the key rotation time interval in months                |`int`| n/a     | yes     |
-
-## dual_auth_delete Inputs
-
-| Name                     | Description                                                    | Type   |Default  |Required |
-|--------------------------|----------------------------------------------------------------|:-------|:--------|:--------|
-| enabled        | If set to true, Key Protect enables a dual authorization policy on a single key.      |`bool`| n/a     | yes     |
+| endpoint_type            | The type of the public or private endpoint to be used for fetching policies. |`string`| n/a     | no      |
+| rotation                 | The key rotation time interval in months                       |`object({ interval_month = number })`| n/a   | Atleast one of rotation/dual_auth_delete    |
+| dual_auth_delete         | Data associated with the dual authorization delete policy.     |`bool`| false | Atleast one of rotation/dual_auth_delete|
 
 Note:
 

--- a/modules/key-protect/main.tf
+++ b/modules/key-protect/main.tf
@@ -30,23 +30,21 @@ resource "ibm_kms_key" "key" {
   encrypted_nonce = (var.encrypted_nonce != null ? var.encrypted_nonce : null)
   iv_value        = (var.iv_value != null ? var.iv_value : null)
   expiration_date = (var.expiration_date != null ? var.expiration_date : null)
-  dynamic "policies" {
-    for_each = length(keys(var.policies)) == 0 ? [] : [var.policies]
+}
 
+resource "ibm_kms_key_policies" "key_policy" {
+  instance_id   = var.is_kp_instance_exist != true ? ibm_resource_instance.kms_instance[0].guid : data.ibm_resource_instance.kms_instance[0].guid
+  key_id        = ibm_kms_key.key.key_id
+  endpoint_type = var.endpoint_type 
+  
+  dynamic "rotation" {
+    for_each = var.rotation == null ? {} : var.rotation
     content {
-      dynamic "rotation" {
-        for_each = length(keys(lookup(policies.value, "rotation", {}))) == 0 ? [] : [lookup(policies.value, "rotation", {})]
-
-        content {
-          interval_month = lookup(rotation.value, "interval_month", null)
-        }
-      }
-      dynamic "dual_auth_delete" {
-        for_each = length(keys(lookup(policies.value, "dual_auth_delete", {}))) == 0 ? [] : [lookup(policies.value, "dual_auth_delete", {})]
-        content {
-          enabled = lookup(dual_auth_delete.value, "enabled", null)
-        }
-      }
+      interval_month = var.rotation.interval_month
     }
   }
-}
+
+  dual_auth_delete {
+    enabled = var.dual_auth_delete
+  }
+} 

--- a/modules/key-protect/variables.tf
+++ b/modules/key-protect/variables.tf
@@ -81,8 +81,22 @@ variable "expiration_date" {
   type        = string
   default     = null
 }
-variable "policies" {
-  description = " Set policies for a key, such as an automatic rotation policy or a dual authorization policy."
-  type        = any
-  default     = {}
+
+######################################
+# Key Protect Key Policies Variables
+######################################
+variable "endpoint_type" {
+  description = "The type of the public or private endpoint to be used for fetching policies."
+  type        = string
+  default     = null
+}
+variable "rotation" {
+  description = "The key rotation time interval in months, with a minimum of 1, and a maximum of 12."
+  type        = object({ interval_month = number })
+  default     = null
+}
+variable "dual_auth_delete" {
+  description = "Enable or disable dual auth delete on keys. Enabled requires 2 levels of approval to delete a key. Default is false."
+  type        = bool
+  default     = false
 }

--- a/test/kms_test.go
+++ b/test/kms_test.go
@@ -1,0 +1,38 @@
+package test
+
+import (
+	"testing"
+	"github.com/gruntwork-io/terratest/modules/terraform"
+	
+)
+
+func TestKMS(t *testing.T) {
+	t.Parallel()
+
+	// Construct the terraform options with default retryable errors to handle the most common retryable errors in
+	// terraform testing.
+	terraformOptions := terraform.WithDefaultRetryableErrors(t, &terraform.Options{
+		// The path to where our Terraform code is located
+		TerraformDir: "../examples/kp-key",
+
+		Vars: map[string]interface{}{
+			"ibm_region" 				: "us-south",
+			"key_name" 					: "test-key",
+			"location" 					: "us-south",
+			"service_name" 				: "test-instance",
+			"allowed_network_policy" 	: "public",
+			"standard_key_type" 		: false,
+			"force_delete" 				: false,
+			"network_access_allowed" 	: "public",
+		},
+
+		VarFiles: []string{"../../terraform.tfvars"}, // api key and resource group reside in this file
+
+		NoColor: true, 
+	})
+	// At the end of the test, run `terraform destroy` to clean up any resources that were created
+	defer terraform.Destroy(t, terraformOptions)
+
+	// This will run `terraform init` and `terraform apply` and fail the test if there are any errors
+	terraform.InitAndApply(t, terraformOptions)
+}


### PR DESCRIPTION
Support for creating policies directly through the key resource is being deprecated soon and this migrates it to the key policy resource. 

Design considerations: 
Rotation isn't required, but if it's declared then it must be a valid integer from 1 to 12.  To handle the user not specifying a rotation schedule, I have it using a dynamic block.  Dual auth delete however is a bool with default value of false, so that can be a simple block. 

Other notes: 
I created a terratest for this as well, utilizing some basic values, to run it create a terraform.tfvars file and add apikey and resource group. 

